### PR TITLE
Update borders.pyi to match latest upstream code

### DIFF
--- a/openpyxl-stubs/styles/borders.pyi
+++ b/openpyxl-stubs/styles/borders.pyi
@@ -6,6 +6,21 @@ from typing import (
     Union,
 )
 
+BORDER_NONE = None
+BORDER_DASHDOT = 'dashDot'
+BORDER_DASHDOTDOT = 'dashDotDot'
+BORDER_DASHED = 'dashed'
+BORDER_DOTTED = 'dotted'
+BORDER_DOUBLE = 'double'
+BORDER_HAIR = 'hair'
+BORDER_MEDIUM = 'medium'
+BORDER_MEDIUMDASHDOT = 'mediumDashDot'
+BORDER_MEDIUMDASHDOTDOT = 'mediumDashDotDot'
+BORDER_MEDIUMDASHED = 'mediumDashed'
+BORDER_SLANTDASHDOT = 'slantDashDot'
+BORDER_THICK = 'thick'
+BORDER_THIN = 'thin'
+
 class Border:
     def __init__(
         self,


### PR DESCRIPTION
The [upstream code of borders.py](https://foss.heptapod.net/openpyxl/openpyxl/-/blob/branch/3.0/openpyxl/styles/borders.py) has been updated. Let's bump our code as well.