### PR TITLE
Make Path-type acceptable for load and save workbook

### DIFF
--- a/openpyxl-stubs/reader/excel.pyi
+++ b/openpyxl-stubs/reader/excel.pyi
@@ -9,13 +9,14 @@ from openpyxl.packaging.manifest import (
 from openpyxl.packaging.relationship import Relationship
 from openpyxl.packaging.workbook import ChildSheet
 from openpyxl.workbook.workbook import Workbook
+from pathlib import Path
 from typing import Union
 from zipfile import ZipFile
 
 def _find_workbook_part(package: Manifest) -> Override: ...
 def _validate_archive(filename: Union[str, BufferedReader, BytesIO]) -> ZipFile: ...
 def load_workbook(
-    filename: Union[str, BufferedReader, BytesIO],
+    filename: Union[str, Path, BufferedReader, BytesIO],
     read_only: bool = ...,
     keep_vba: bool = ...,
     data_only: bool = ...,

--- a/openpyxl-stubs/workbook/workbook.pyi
+++ b/openpyxl-stubs/workbook/workbook.pyi
@@ -4,6 +4,7 @@ from openpyxl.workbook.defined_name import DefinedName
 from openpyxl.worksheet._read_only import ReadOnlyWorksheet
 from openpyxl.worksheet._write_only import WriteOnlyWorksheet
 from openpyxl.worksheet.worksheet import Worksheet
+from pathlib import Path
 from typing import (
     List,
     Optional,
@@ -58,7 +59,7 @@ class Workbook:
     @property
     def read_only(self) -> bool: ...
     def remove(self, worksheet: Union[Chartsheet, Worksheet]) -> None: ...
-    def save(self, filename: Union[str, IO[bytes]]) -> None: ...
+    def save(self, filename: Union[str, Path, IO[bytes]]) -> None: ...
     @property
     def sheetnames(self) -> List[str]: ...
     @property


### PR DESCRIPTION
I'm using loading and saving openpyxl Workbooks with Path in all my projects which is convenient with different OS. So I think it would be nice if mypy would stop alarming me about error, because it works okay here (will be glad to be corrected if you provide info of different behavior)